### PR TITLE
Change the generated Service's suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+-  Add service template (#23) 
+
+### Changed
+
+- **Refact Change MinecraftSpec** (#23)
+- Change the generated Service's suffix (#30) 
+
 ## [0.1.0] - 2021-10-24
 
 ### Added

--- a/api/v1alpha1/minecraft_types.go
+++ b/api/v1alpha1/minecraft_types.go
@@ -210,6 +210,10 @@ func (m *Minecraft) PrefixedName() string {
 	return "mcing-" + m.Name
 }
 
+func (m *Minecraft) HeadlessServiceName() string {
+	return m.PrefixedName() + "-headless"
+}
+
 //+kubebuilder:object:root=true
 
 // MinecraftList contains a list of Minecraft

--- a/controllers/minecraft_controller.go
+++ b/controllers/minecraft_controller.go
@@ -116,7 +116,7 @@ func (r *MinecraftReconciler) reconcileStatefulSet(ctx context.Context, mc *mcin
 		sts.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: labels,
 		}
-		sts.Spec.ServiceName = mc.PrefixedName()
+		sts.Spec.ServiceName = mc.HeadlessServiceName()
 		sts.Spec.VolumeClaimTemplates = make([]corev1.PersistentVolumeClaim, len(mc.Spec.VolumeClaimTemplates))
 		for i, v := range mc.Spec.VolumeClaimTemplates {
 			pvc := v.ToCoreV1()
@@ -223,8 +223,8 @@ func (r *MinecraftReconciler) reconcileService(ctx context.Context, mc *mcingv1a
 	svc := &corev1.Service{}
 	svc.Namespace = mc.Namespace
 	svc.Name = mc.PrefixedName()
-	if !headless {
-		svc.Name = mc.PrefixedName() + "-tmpl"
+	if headless {
+		svc.Name = mc.HeadlessServiceName()
 	}
 	var orig, updated *corev1.ServiceSpec
 	result, err := ctrl.CreateOrUpdate(ctx, r.Client, svc, func() error {


### PR DESCRIPTION
- Add `-headless`suffix to the name of HeadlessService.
- Removed the suffix for services created from ServiceTemplate.

Signed-off-by: kouki <kouworld0123@gmail.com>