### PR TITLE
chore: update release config and renovate labels

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -3,7 +3,16 @@ changelog:
     labels:
       - ignore-for-release
       - ci
+      - duplicate
+      - invalid
+      - question
+      - wontfix
+      - help wanted
   categories:
+    - title: Security
+      labels:
+        - area/security
+        - dependencies/security
     - title: Features
       labels:
         - enhancement
@@ -16,9 +25,6 @@ changelog:
     - title: Removed
       labels:
         - remove
-    - title: Security
-      labels:
-        - security
     - title: Dependencies
       labels:
         - dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "vulnerabilityAlerts": {
+    "labels": ["dependencies/security"]
+  },
   "labels": ["dependencies"],
   "automerge": true,
   "extends": [


### PR DESCRIPTION
Updates the release configuration to better handle labels and adds security label configuration for Renovate.