### PR TITLE
ci: skip workflows for unrelated file changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,0 +1,25 @@
+src:
+  - "*.yml"
+  - "*.yaml"
+  - "**/*.go"
+  - "go.mod"
+  - "go.sum"
+  - "Makefile"
+  - "Dockerfile"
+  - "Tiltfile"
+  - "aqua.yaml"
+  - "api/**"
+  - "cmd/**"
+  - "config/**"
+  - "e2e/**"
+  - "hack/**"
+  - "internal/**"
+  - "pkg/**"
+  - ".github/workflows/ci.yaml" # Trigger CI when the CI workflow config itself changes
+  - ".github/filters.yaml" # Trigger CI when filters config changes
+
+docs:
+  - "docs/**"
+  - ".github/workflows/mdbook.yaml"
+  - ".github/filters.yaml" # Trigger docs CI when filters config changes
+  - "aqua.yaml"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,21 @@ on:
     branches:
       - "main"
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: .github/filters.yaml
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.head_ref, 'release/v') }}
+
     name: Build binaries
     runs-on: ubuntu-latest
     steps:
@@ -20,6 +34,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: make build
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.head_ref, 'release/v') }}
+
     name: Small tests
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +60,9 @@ jobs:
           - "1.33.7" # renovate: kindest/node
           - "1.32.11" # renovate: kindest/node
     runs-on: ubuntu-24.04
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.head_ref, 'release/v') }}
+
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -73,12 +93,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check e2e matrix status
-        if: ${{ needs.e2e.result != 'success' }}
+        if: ${{ needs.e2e.result != 'success' && needs.e2e.result != 'skipped' }}
         run: exit 1
 
   tilt:
     name: Run tilt ci
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.head_ref, 'release/v') }}
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -94,7 +117,10 @@ jobs:
       - run: tilt ci
   dry-run-release:
     name: Dry-run release
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.head_ref, 'release/v') }}
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -5,7 +5,21 @@ on:
     branches:
       - "main"
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: .github/filters.yaml
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' || startsWith(github.head_ref, 'release/v') }}
+
     name: Build book
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary
This PR updates `ci.yaml` and `mdbook.yaml` to skip workflow execution when changes are detected in unrelated files (e.g., documentation), while ensuring they still run on release branches.

## Changes
- Introduced `dorny/paths-filter` to filter changes.
- `ci.yaml`: Skips jobs if changes are limited to `docs/**`, `**.md`, etc.
- `mdbook.yaml`: Runs only if `docs/**` or the workflow itself is modified.
- Added logic to always run workflows for branches starting with `release/v`.

## Verification
- Verified logic: Unrelated changes result in skipped jobs (which pass required checks), while related changes trigger full execution.
