### PR TITLE
chore: Apply strict golangci-lint rules and fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,505 @@
-version: 2
+# This file is licensed under the terms of the MIT license https://opensource.org/license/mit
+# Copyright (c) 2021-2025 Marat Reimers
+
+## Golden config for golangci-lint v2.8.0
+#
+# This is the best config for golangci-lint based on my experience and opinion.
+# It is very strict, but not extremely strict.
+# Feel free to adapt it to suit your needs.
+# If this config helps you, please consider keeping a link to this repo (see the next comment).
+
+# Based on https://github.com/maratori/golangci-lint-config
+
+version: "2"
+
 run:
-  deadline: 5m
-  allow-parallel-runners: true
+  skip-files:
+    - "^zz_generated.*"
 
 issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 50
   exclude-rules:
-    - path: "api/**/zz_generated.deepcopy.go"
+    - path: "_test\\.go|e2e/.*\\.go"
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - funlen
+        - gocognit
+        - cyclop
+        - maintidx
+        - forcetypeassert
+        - exhaustruct
+        - gochecknoglobals
+        - gochecknoinits
+        - bodyclose
+        - revive
+    - path: "_test\\.go|e2e/.*\\.go"
+      text: "should not use dot imports"
+      linters:
+        - revive
+
+formatters:
+  enable:
+    - goimports # checks if the code and import statements are formatted according to the 'goimports' command
+    - golines # checks if code is formatted, and fixes long lines
+
+    ## you may want to enable
+    #- gci # checks if code and import statements are formatted, with additional rules
+    #- gofmt # checks if the code is formatted according to 'gofmt' command
+    - gofumpt # enforces a stricter format than 'gofmt', while being backwards compatible
+    #- swaggo # formats swaggo comments
+
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    goimports:
+      # A list of prefixes, which, if set, checks import paths
+      # with the given prefixes are grouped after 3rd-party packages.
+      # Default: []
+      local-prefixes:
+        - github.com/kmdkuk/mcing
+
+    golines:
+      # Target maximum line length.
+      # Default: 100
+      max-len: 120
 
 linters:
-  disable-all: true
-  enable-all: true
+  enable:
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - canonicalheader # checks whether net/http.Header uses canonical header
+    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+    - cyclop # checks function and package cyclomatic complexity
+    - depguard # checks if package imports are in a list of acceptable packages
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - embeddedstructfieldcheck # checks embedded types in structs
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
+    - fatcontext # detects nested contexts in loops
+    - forbidigo # forbids identifiers
+    - funcorder # checks the order of functions, methods, and constructors
+    - funlen # tool for detection of long functions
+    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoglobals # checks that no global variables exist
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gochecksumtype # checks exhaustiveness on Go "sum types"
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godoclint # checks Golang's documentation practice
+    - godot # checks if comments end in a period
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
+    - ineffassign # detects when assignments to existing variables are not used
+    - intrange # finds places where for loops could make use of an integer range
+    - iotamixing # checks if iotas are being used in const blocks with other non-iota declarations
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - mirror # reports wrong mirror patterns of bytes/strings usage
+    - mnd # detects magic numbers
+    - modernize # suggests simplifications to Go code, using modern language and library features
+    - musttag # enforces field tags in (un)marshaled structs
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nonamedreturns # reports all named returns
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - protogetter # reports direct reads from proto message fields when getters should be used
+    - reassign # checks that package variables are not reassigned
+    - recvcheck # checks for receiver type consistency
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sloglint # ensure consistent code style when using log/slog
+    - spancheck # checks for mistakes with OpenTelemetry/Census spans
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - testableexamples # checks if examples are testable (have an expected output)
+    - testifylint # checks usage of github.com/stretchr/testify
+    # - testpackage # makes you use a separate _test package
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unqueryvet # detects SELECT * in SQL queries and SQL builders, encouraging explicit column selection
+    - unused # checks for unused constants, variables, functions and types
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - usetesting # reports uses of functions with replacement inside the testing package
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
 
-linters-settings:
-  gofumpt:
-    extra-rules:
-      - name: "no-blank-imports"
-  govet:
-    disable-all: false
-    settings:
-      shadow: true
-      printf: true
-  staticcheck:
-    checks: ["all"]
+    ## you may want to enable
+    #- arangolint # opinionated best practices for arangodb client
+    #- decorder # checks declaration order and count of types, constants, variables and functions
+    - exhaustruct # [highly recommend to enable] checks if all structure fields are initialized
+    - ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
+    #- godox # detects usage of FIXME, TODO and other keywords inside comments
+    #- goheader # checks is file header matches to pattern
+    #- inamedparam # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
+    #- interfacebloat # checks the number of methods inside an interface
+    #- ireturn # accept interfaces, return concrete types
+    #- noinlineerr # disallows inline error handling `if err := ...; err != nil {`
+    #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
+    #- tagalign # checks that struct tags are well aligned
+    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- wrapcheck # checks that errors returned from external packages are wrapped
+    #- zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
+
+    ## disabled
+    #- containedctx # detects struct contained context.Context field
+    #- contextcheck # [too many false positives] checks the function whether use a non-inherited context
+    #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    #- dupword # [useless without config] checks for duplicate words in the source code
+    #- err113 # [too strict] checks the errors handling expressions
+    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
+    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
+    #- gomodguard # [use more powerful depguard] allow and block lists linter for direct Go module dependencies
+    #- gosmopolitan # reports certain i18n/l10n anti-patterns in your Go codebase
+    #- grouper # analyzes expression groups
+    #- importas # enforces consistent import aliases
+    #- lll # [replaced by golines] reports long lines
+    #- maintidx # measures the maintainability index of each function
+    #- misspell # [useless] finds commonly misspelled English words in comments
+    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    #- tagliatelle # checks the struct tags
+    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+    #- wsl_v5 # [too strict and mostly code is not more readable] add or remove empty lines
+
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    cyclop:
+      # The maximal code complexity to report.
+      # Default: 10
+      max-complexity: 30
+      # The maximal average package complexity.
+      # If it's higher than 0.0 (float) the check is enabled.
+      # Default: 0.0
+      package-average: 10.0
+
+    depguard:
+      # Rules to apply.
+      #
+      # Variables:
+      # - File Variables
+      #   Use an exclamation mark `!` to negate a variable.
+      #   Example: `!$test` matches any file that is not a go test file.
+      #
+      #   `$all` - matches all go files
+      #   `$test` - matches all go test files
+      #
+      # - Package Variables
+      #
+      #   `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+      #
+      # Default (applies if no custom rules are defined): Only allow $gostd in all files.
+      rules:
+        "deprecated":
+          # List of file globs that will match this list of settings to compare against.
+          # By default, if a path is relative, it is relative to the directory where the golangci-lint command is executed.
+          # The placeholder '${base-path}' is substituted with a path relative to the mode defined with `run.relative-path-mode`.
+          # The placeholder '${config-path}' is substituted with a path relative to the configuration file.
+          # Default: $all
+          files:
+            - "$all"
+          # List of packages that are not allowed.
+          # Entries can be a variable (starting with $), a string prefix, or an exact match (if ending with $).
+          # Default: []
+          deny:
+            - pkg: github.com/golang/protobuf
+              desc: Use google.golang.org/protobuf instead, see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+            - pkg: github.com/satori/go.uuid
+              desc: Use github.com/google/uuid instead, satori's package is not maintained
+            - pkg: github.com/gofrs/uuid$
+              desc: Use github.com/gofrs/uuid/v5 or later, it was not a go module before v5
+        "non-test files":
+          files:
+            - "!$test"
+          deny:
+            - pkg: math/rand$
+              desc: Use math/rand/v2 instead, see https://go.dev/blog/randv2
+        "non-main files":
+          files:
+            - "!**/main.go"
+          deny:
+            - pkg: log$
+              desc: Use log/slog instead, see https://go.dev/blog/slog
+
+    embeddedstructfieldcheck:
+      # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.
+      # Default: false
+      forbid-mutex: true
+
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: true
+
+    exhaustive:
+      # Program elements to check for exhaustiveness.
+      # Default: [ switch ]
+      check:
+        - switch
+        - map
+
+    exhaustruct:
+      # List of regular expressions to match type names that should be excluded from processing.
+      # Anonymous structs can be matched by '<anonymous>' alias.
+      # Has precedence over `include`.
+      # Each regular expression must match the full type name, including package path.
+      # For example, to match type `net/http.Cookie` regular expression should be `.*/http\.Cookie`,
+      # but not `http\.Cookie`.
+      # Default: []
+      exclude:
+        # std libs
+        - ^net/http.Client$
+        - ^net/http.Cookie$
+        - ^net/http.Request$
+        - ^net/http.Response$
+        - ^net/http.Server$
+        - ^net/http.Transport$
+        - ^net/url.URL$
+        - ^os/exec.Cmd$
+        - ^reflect.StructField$
+        # public libs
+        - ^github.com/Shopify/sarama.Config$
+        - ^github.com/Shopify/sarama.ProducerMessage$
+        - ^github.com/mitchellh/mapstructure.DecoderConfig$
+        - ^github.com/prometheus/client_golang/.+Opts$
+        - ^github.com/spf13/cobra.Command$
+        - ^github.com/spf13/cobra.CompletionOptions$
+        - ^github.com/stretchr/testify/mock.Mock$
+        - ^github.com/testcontainers/testcontainers-go.+Request$
+        - ^github.com/testcontainers/testcontainers-go.FromDockerfile$
+        - ^golang.org/x/tools/go/analysis.Analyzer$
+        - ^google.golang.org/protobuf/.+Options$
+        - ^gopkg.in/yaml.v3.Node$
+        - ^k8s\.io/api/.*$
+        - ^k8s\.io/apimachinery/.*$
+        - ^sigs\.k8s\.io/controller-runtime/.*$
+        - ^github\.com/kmdkuk/mcing/api/v1alpha1\..*$
+        - .*<anonymous>$
+      # Allows empty structures in return statements.
+      # Default: false
+      allow-empty-returns: true
+
+    funcorder:
+      # Checks if the exported methods of a structure are placed before the non-exported ones.
+      # Default: true
+      struct-method: false
+
+    funlen:
+      # Checks the number of lines in a function.
+      # If lower than 0, disable the check.
+      # Default: 60
+      lines: 100
+      # Checks the number of statements in a function.
+      # If lower than 0, disable the check.
+      # Default: 40
+      statements: 50
+
+    gochecksumtype:
+      # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
+      # Default: true
+      default-signifies-exhaustive: false
+
+    gocognit:
+      # Minimal code complexity to report.
+      # Default: 30 (but we recommend 10-20)
+      min-complexity: 20
+
+    gocritic:
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be found at https://go-critic.com/overview.
+      settings:
+        captLocal:
+          # Whether to restrict checker to params only.
+          # Default: true
+          paramsOnly: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          # Default: true
+          skipRecvDeref: false
+
+    godoclint:
+      # List of rules to enable in addition to the default set.
+      # Default: empty
+      enable:
+        # Assert no unused link in godocs.
+        # https://github.com/godoc-lint/godoc-lint?tab=readme-ov-file#no-unused-link
+        - no-unused-link
+        # Require proper doc links to standard library declarations where applicable.
+        # https://github.com/godoc-lint/godoc-lint?tab=readme-ov-file#require-stdlib-doclink
+        - require-stdlib-doclink
+
+    govet:
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Disable analyzers by name.
+      # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
+      # Default: []
+      disable:
+        - fieldalignment # too strict
+      # Settings per analyzer.
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          # Default: false
+          strict: false
+
+    inamedparam:
+      # Skips check for interface methods with only a single parameter.
+      # Default: false
+      skip-single-param: true
+
+    mnd:
+      # List of function patterns to exclude from analysis.
+      # Values always ignored: `time.Date`,
+      # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+      # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+      # Default: []
+      ignored-functions:
+        - args.Error
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+        - prometheus.ExponentialBuckets.*
+        - prometheus.LinearBuckets
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 0
+
+    nolintlint:
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation: [funlen, gocognit, golines]
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+
+    perfsprint:
+      # Optimizes into strings concatenation.
+      # Default: true
+      strconcat: false
+
+    reassign:
+      # Patterns for global variable names that are checked for reassignment.
+      # See https://github.com/curioswitch/go-reassign#usage
+      # Default: ["EOF", "Err.*"]
+      patterns:
+        - ".*"
+
+    rowserrcheck:
+      # database/sql is always checked.
+      # Default: []
+      packages:
+        - github.com/jmoiron/sqlx
+
+    sloglint:
+      # Enforce not using global loggers.
+      # Values:
+      # - "": disabled
+      # - "all": report all global loggers
+      # - "default": report only the default slog logger
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
+      # Default: ""
+      no-global: all
+      # Enforce using methods that accept a context.
+      # Values:
+      # - "": disabled
+      # - "all": report all contextless calls
+      # - "scope": report only if a context exists in the scope of the outermost function
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
+      # Default: ""
+      context: scope
+
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+      # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      checks:
+        - all
+        # Incorrect or missing package comment.
+        # https://staticcheck.dev/docs/checks/#ST1000
+        - -ST1000
+        # Use consistent method receiver names.
+        # https://staticcheck.dev/docs/checks/#ST1016
+        - -ST1016
+        # Omit embedded fields from selector expression.
+        # https://staticcheck.dev/docs/checks/#QF1008
+        - -QF1008
+
+    usetesting:
+      # Enable/disable `os.TempDir()` detections.
+      # Default: false
+      os-temp-dir: true
+
+  exclusions:
+    # Log a warning if an exclusion rule is unused.
+    # Default: false
+    warn-unused: true
+    # Predefined exclusion rules.
+    # Default: []
+    presets:
+      - std-error-handling
+      - common-false-positives
+    # Excluding configuration per-path, per-linter, per-text and per-source.
+    rules:
+      # - source: "TODO"
+      #   linters: [godot]
+      - text: "should have a package comment"
+        linters: [revive]
+      # - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
+      #   linters: [revive]
+      # - text: 'package comment should be of the form ".+"'
+      #   source: "// ?(nolint|TODO)"
+      #   linters: [revive]
+      # - text: 'comment on exported \S+ \S+ should be of the form ".+"'
+      #   source: "// ?(nolint|TODO)"
+      #   linters: [revive, staticcheck]
+      # - path: '_test\.go'
+      #   linters:
+      #     - bodyclose
+      #     - dupl
+      #     - errcheck
+      #     - funlen
+      #     - goconst
+      #     - gosec
+      #     - noctx
+      #     - wrapcheck
+      #     - exhaustruct

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -24,11 +24,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
+//nolint:gochecknoglobals // required by kubebuilder
 var (
-	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "mcing.kmdkuk.com", Version: "v1alpha1"}
+	// GroupVersion is group version used to register these objects.
+	GroupVersion = schema.GroupVersion{
+		Group:   "mcing.kmdkuk.com",
+		Version: "v1alpha1",
+	}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // dot imports for tests
+	. "github.com/onsi/gomega"    //nolint:revive // dot imports for tests
 
 	admissionv1 "k8s.io/api/admission/v1"
 	//+kubebuilder:scaffold:imports
@@ -45,11 +45,14 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+//nolint:gochecknoglobals // test setup
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -60,7 +63,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = context.WithCancel(context.TODO()) //nolint:fatcontext // test logic
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -125,16 +128,20 @@ var _ = BeforeSuite(func() {
 	}()
 
 	// wait for the webhook server to get ready
-	dialer := &net.Dialer{Timeout: time.Second}
+	dialer := &net.Dialer{Timeout: time.Second} //nolint:exhaustruct // standard dialer
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
-		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		conn, err := tls.DialWithDialer(
+			dialer,
+			"tcp",
+			addrPort,
+			&tls.Config{InsecureSkipVerify: true}, //nolint:gosec,exhaustruct // intended for tests
+		)
 		if err != nil {
 			return err
 		}
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/cmd/mcing-agent/cmd/root.go
+++ b/cmd/mcing-agent/cmd/root.go
@@ -19,12 +19,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+
+// Package cmd represents the base command when called without any subcommands.
 package cmd
 
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"path"
@@ -33,32 +34,36 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	james4krcon "github.com/james4k/rcon"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+
 	"github.com/kmdkuk/mcing/pkg/config"
 	"github.com/kmdkuk/mcing/pkg/constants"
 	"github.com/kmdkuk/mcing/pkg/proto"
 	"github.com/kmdkuk/mcing/pkg/rcon"
 	"github.com/kmdkuk/mcing/pkg/server"
 	"github.com/kmdkuk/mcing/pkg/watcher"
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/keepalive"
 )
 
 const (
-	grpcDefaultAddr = ":9080"
+	grpcDefaultAddr  = ":9080"
+	minKeepaliveTime = 10 * time.Second
+	rconRetryCount   = 30
+	watcherInterval  = 10 * time.Second
 )
 
-var flags struct {
+type flags struct {
 	address string
 }
 
 // InterceptorLogger adapts zap logger to interceptor logger.
 // This code is simple enough to be copied and not imported.
 func InterceptorLogger(l *zap.Logger) logging.Logger {
-	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		f := make([]zap.Field, 0, len(fields)/2)
+	return logging.LoggerFunc(func(_ context.Context, lvl logging.Level, msg string, fields ...any) {
+		f := make([]zap.Field, 0, len(fields)/2) //nolint:mnd // fields are key-value pairs
 
 		for i := 0; i < len(fields); i += 2 {
 			key := fields[i]
@@ -66,13 +71,13 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 
 			switch v := value.(type) {
 			case string:
-				f = append(f, zap.String(key.(string), v))
+				f = append(f, zap.String(fmt.Sprintf("%v", key), v))
 			case int:
-				f = append(f, zap.Int(key.(string), v))
+				f = append(f, zap.Int(fmt.Sprintf("%v", key), v))
 			case bool:
-				f = append(f, zap.Bool(key.(string), v))
+				f = append(f, zap.Bool(fmt.Sprintf("%v", key), v))
 			default:
-				f = append(f, zap.Any(key.(string), v))
+				f = append(f, zap.Any(fmt.Sprintf("%v", key), v))
 			}
 		}
 
@@ -93,121 +98,130 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 	})
 }
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "mcing-agent",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
+// NewRootCmd represents the base command when called without any subcommands.
+func NewRootCmd() *cobra.Command {
+	f := flags{address: ""}
+	rootCmd := &cobra.Command{
+		Use:   "mcing-agent",
+		Short: "A brief description of your application",
+		Long: `A longer description that spans multiple lines and likely contains
 examples and usage of using your application. For example:
 
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		zapLogger, err := zap.NewProduction(zap.AddStacktrace(zapcore.DPanicLevel))
+		// Uncomment the following line if your bare application
+		// has an action associated with it:
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runAgent(f)
+		},
+	}
+
+	fs := rootCmd.Flags()
+	fs.StringVar(&f.address, "address", grpcDefaultAddr, "Listening address and port for gRPC API.")
+
+	rootCmd.AddCommand(newVersionCmd())
+	return rootCmd
+}
+
+func runAgent(f flags) error {
+	zapLogger, err := zap.NewProduction(zap.AddStacktrace(zapcore.DPanicLevel))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = zapLogger.Sync()
+	}()
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", f.address)
+	if err != nil {
+		return err
+	}
+	grpcLogger := zapLogger.Named("grpc")
+	opts := []logging.Option{
+		logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
+		// Add any other option (check functions starting with logging.With).
+	}
+	grpcServer := grpc.NewServer(
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             minKeepaliveTime,
+			PermitWithoutStream: false,
+		}),
+		grpc.ChainUnaryInterceptor(
+			logging.UnaryServerInterceptor(InterceptorLogger(grpcLogger), opts...),
+			// Add any other interceptor you want.
+		),
+		grpc.ChainStreamInterceptor(
+			logging.StreamServerInterceptor(InterceptorLogger(grpcLogger), opts...),
+			// Add any other interceptor you want.
+		),
+	)
+	retryCount := 0
+	var conn *james4krcon.RemoteConsole
+	var props map[string]string
+	for {
+		props, err = config.ParseServerPropsFromPath(path.Join(constants.DataPath, constants.ServerPropsName))
 		if err != nil {
 			return err
 		}
-		defer func() {
-			err = zapLogger.Sync()
-		}()
 
-		lis, err := net.Listen("tcp", flags.address)
-		if err != nil {
+		hostPort := "127.0.0.1:" + props[constants.RconPortProps]
+		password := os.Getenv(constants.RconPasswordEnvName)
+
+		conn, err = rcon.NewConn(hostPort, password)
+		if err == nil {
+			break
+		}
+		if retryCount > rconRetryCount {
 			return err
 		}
-		grpcLogger := zapLogger.Named("grpc")
-		opts := []logging.Option{
-			logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
-			// Add any other option (check functions starting with logging.With).
+		retryCount++
+		wait := 1 * retryCount
+		zapLogger.Error(fmt.Sprintf("connection error, retry after %d seconds", wait), zap.Error(err))
+		time.Sleep(time.Duration(wait) * time.Second)
+	}
+	defer func() {
+		err = conn.Close()
+	}()
+
+	proto.RegisterAgentServer(grpcServer, server.NewAgentService(zapLogger, conn))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		err := grpcServer.Serve(lis)
+		if err != nil {
+			zapLogger.Error("failed to serve", zap.Error(err))
+			cancel()
 		}
-		grpcServer := grpc.NewServer(
-			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-				MinTime: 10 * time.Second,
-			}),
-			grpc.ChainUnaryInterceptor(
-				logging.UnaryServerInterceptor(InterceptorLogger(grpcLogger), opts...),
-				// Add any other interceptor you want.
-			),
-			grpc.ChainStreamInterceptor(
-				logging.StreamServerInterceptor(InterceptorLogger(grpcLogger), opts...),
-				// Add any other interceptor you want.
-			),
-		)
-		retryCount := 0
-		var conn *james4krcon.RemoteConsole
-		for {
-			props, err := config.ParseServerPropsFromPath(path.Join(constants.DataPath, constants.ServerPropsName))
-			if err != nil {
-				return err
-			}
+	})
 
-			hostPort := "localhost:" + props[constants.RconPortProps]
-			password := os.Getenv(constants.RconPasswordEnvName)
+	wg.Add(1)
+	go func(ctx context.Context) {
+		defer wg.Done()
+		<-ctx.Done()
+		grpcServer.GracefulStop()
+	}(ctx)
 
-			conn, err = rcon.NewConn(hostPort, password)
-			if err == nil {
-				break
-			}
-			if retryCount > 30 {
-				return err
-			}
-			retryCount++
-			wait := 1 * retryCount
-			zapLogger.Error(fmt.Sprintf("connection error, retry after %d seconds", wait), zap.Error(err))
-			time.Sleep(time.Duration(wait) * time.Second)
+	wg.Add(1)
+	go func(ctx context.Context) {
+		defer wg.Done()
+		err := watcher.Watch(ctx, conn, watcherInterval)
+		if err != nil {
+			zapLogger.Error("failed to watch", zap.Error(err))
 		}
-		defer func() {
-			err = conn.Close()
-		}()
+	}(ctx)
 
-		proto.RegisterAgentServer(grpcServer, server.NewAgentService(zapLogger, conn))
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := grpcServer.Serve(lis)
-			if err != nil {
-				zapLogger.Error("failed to serve", zap.Error(err))
-				cancel()
-			}
-		}()
-
-		wg.Add(1)
-		go func(ctx context.Context) {
-			defer wg.Done()
-			<-ctx.Done()
-			grpcServer.GracefulStop()
-		}(ctx)
-
-		wg.Add(1)
-		go func(ctx context.Context) {
-			defer wg.Done()
-			err := watcher.Watch(ctx, conn, 10*time.Second)
-			if err != nil {
-				zapLogger.Error("failed to watch", zap.Error(err))
-			}
-		}(ctx)
-
-		wg.Wait()
-		return nil
-	},
+	wg.Wait()
+	return nil
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
+	if err := NewRootCmd().Execute(); err != nil {
+		os.Exit(1)
 	}
-}
-
-func init() {
-	fs := rootCmd.Flags()
-	fs.StringVar(&flags.address, "address", grpcDefaultAddr, "Listening address and port for gRPC API.")
 }

--- a/cmd/mcing-agent/cmd/version.go
+++ b/cmd/mcing-agent/cmd/version.go
@@ -13,40 +13,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (
 	"fmt"
 
-	"github.com/kmdkuk/mcing/pkg/version"
 	"github.com/spf13/cobra"
+
+	"github.com/kmdkuk/mcing/pkg/version"
 )
 
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
+// newVersionCmd represents the version command.
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "A brief description of your command",
+		Long: `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
 
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("version: %s-%s (%s)\n", version.Version, version.Revision, version.BuildDate)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+		Run: func(_ *cobra.Command, _ []string) {
+			//nolint:forbidigo // cli output
+			fmt.Printf("version: %s-%s (%s)\n", version.Version, version.Revision, version.BuildDate)
+		},
+	}
 }

--- a/cmd/mcing-controller/cmd/root.go
+++ b/cmd/mcing-controller/cmd/root.go
@@ -7,13 +7,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kmdkuk/mcing/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/kmdkuk/mcing/pkg/version"
 )
 
-var config struct {
+// Config represents the configuration for the controller.
+type Config struct {
 	metricsAddr          string
 	probeAddr            string
 	enableLeaderElection bool
@@ -26,41 +28,86 @@ var config struct {
 	interval             time.Duration
 }
 
-var rootCmd = &cobra.Command{
-	Use:   "mcing-controller",
-	Short: "mcing controller",
-	Long:  "mcing controller",
+// NewRootCmd represents the base command when called without any subcommands.
+func NewRootCmd() *cobra.Command {
+	var (
+		metricAddr           string
+		probeAddr            string
+		enableLeaderElection bool
+		webhookCertPath      string
+		webhookCertName      string
+		webhookCertKey       string
+		zapOpts              zap.Options
+		initImageName        string
+		agentImageName       string
+		interval             time.Duration
+	)
 
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		return subMain()
-	},
-}
+	rootCmd := &cobra.Command{
+		Use:   "mcing-controller",
+		Short: "mcing controller",
+		Long:  "mcing controller",
 
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			cfg := Config{
+				metricsAddr:          metricAddr,
+				probeAddr:            probeAddr,
+				enableLeaderElection: enableLeaderElection,
+				webhookCertPath:      webhookCertPath,
+				webhookCertName:      webhookCertName,
+				webhookCertKey:       webhookCertKey,
+				zapOpts:              zapOpts,
+				initImageName:        initImageName,
+				agentImageName:       agentImageName,
+				interval:             interval,
+			}
+			return subMain(cfg)
+		},
 	}
-}
 
-func init() {
 	fs := rootCmd.Flags()
-	fs.StringVar(&config.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	fs.StringVar(&config.probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	fs.BoolVar(&config.enableLeaderElection, "leader-elect", false,
+	fs.StringVar(&metricAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	fs.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	fs.StringVar(&config.webhookCertPath, "webhook-cert-path", "/tmp/k8s-webhook-server/serving-certs", "The directory that contains the webhook certificate.")
-	fs.StringVar(&config.webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
-	fs.StringVar(&config.webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	fs.StringVar(&config.initImageName, "init-image-name", "ghcr.io/kmdkuk/mcing-init:"+strings.TrimPrefix(version.Version, "v"), "mcing-init image name")
-	fs.StringVar(&config.agentImageName, "agent-image-name", "ghcr.io/kmdkuk/mcing-agent:"+strings.TrimPrefix(version.Version, "v"), "mcing-agent image name")
-	fs.DurationVar(&config.interval, "check-interval", 1*time.Minute, "Interval of minecraft maintenance")
+	fs.StringVar(
+		&webhookCertPath,
+		"webhook-cert-path",
+		"/tmp/k8s-webhook-server/serving-certs",
+		"The directory that contains the webhook certificate.",
+	)
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
+	fs.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	fs.StringVar(
+		&initImageName,
+		"init-image-name",
+		"ghcr.io/kmdkuk/mcing-init:"+strings.TrimPrefix(version.Version, "v"),
+		"mcing-init image name",
+	)
+	fs.StringVar(
+		&agentImageName,
+		"agent-image-name",
+		"ghcr.io/kmdkuk/mcing-agent:"+strings.TrimPrefix(version.Version, "v"),
+		"mcing-agent image name",
+	)
+	fs.DurationVar(&interval, "check-interval", 1*time.Minute, "Interval of minecraft maintenance")
 
 	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(goflags)
-	config.zapOpts.BindFlags(goflags)
+	zapOpts.BindFlags(goflags)
 
 	fs.AddGoFlagSet(goflags)
+
+	return rootCmd
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() {
+	if err := NewRootCmd().Execute(); err != nil {
+		//nolint:forbidigo // cli output
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/mcing-controller/cmd/run.go
+++ b/cmd/mcing-controller/cmd/run.go
@@ -4,6 +4,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -11,12 +12,8 @@ import (
 	"path/filepath"
 	"strconv"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // required for authentication
 
-	mcingv1alpha1 "github.com/kmdkuk/mcing/api/v1alpha1"
-	"github.com/kmdkuk/mcing/internal/controller"
-	"github.com/kmdkuk/mcing/internal/minecraft"
-	"github.com/kmdkuk/mcing/pkg/agent"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -26,58 +23,40 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/go-logr/logr"
+
+	mcingv1alpha1 "github.com/kmdkuk/mcing/api/v1alpha1"
+	"github.com/kmdkuk/mcing/internal/controller"
+	"github.com/kmdkuk/mcing/internal/minecraft"
+	"github.com/kmdkuk/mcing/pkg/agent"
 	//+kubebuilder:scaffold:imports
 )
 
-var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
-)
-
-func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	utilruntime.Must(mcingv1alpha1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
-}
-
-func subMain() error {
+// subMain is the actual main function.
+func subMain(config Config) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&config.zapOpts)))
+	setupLog := ctrl.Log.WithName("setup")
 	mcMgrLog := ctrl.Log.WithName("minecraft-manager")
 
-	// Create watchers for metrics and webhooks certificates
-	var webhookCertWatcher *certwatcher.CertWatcher
-	var tlsOpts []func(*tls.Config)
-	// Initial webhook TLS options
-	webhookTLSOpts := tlsOpts
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(mcingv1alpha1.AddToScheme(scheme))
 
-	if len(config.webhookCertPath) > 0 {
-		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
-			"webhook-cert-path", config.webhookCertPath, "webhook-cert-name", config.webhookCertName, "webhook-cert-key", config.webhookCertKey)
-
-		var err error
-		webhookCertWatcher, err = certwatcher.New(
-			filepath.Join(config.webhookCertPath, config.webhookCertName),
-			filepath.Join(config.webhookCertPath, config.webhookCertKey),
-		)
-		if err != nil {
-			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
-			os.Exit(1)
-		}
-
-		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
-			config.GetCertificate = webhookCertWatcher.GetCertificate
-		})
+	webhookCertWatcher, webhookTLSOpts, err := setupWebhookCertWatcher(config, setupLog)
+	if err != nil {
+		setupLog.Error(err, "Failed to initialize webhook certificate watcher")
+		os.Exit(1)
 	}
 
 	webhookAddr := ":9443"
 	host, p, err := net.SplitHostPort(webhookAddr)
 	if err != nil {
-		return fmt.Errorf("invalid webhook address: %s, %v", webhookAddr, err)
+		return fmt.Errorf("invalid webhook address: %s, %w", webhookAddr, err)
 	}
 	port, err := strconv.Atoi(p)
 	if err != nil {
-		return fmt.Errorf("invalid webhook address: %s, %v", webhookAddr, err)
+		return fmt.Errorf("invalid webhook address: %s, %w", webhookAddr, err)
 	}
 
 	webhookServer := webhook.NewServer(webhook.Options{
@@ -99,7 +78,7 @@ func subMain() error {
 		return err
 	}
 
-	af := agent.NewAgentFactory()
+	af := agent.NewFactory()
 
 	minecraftMgr := minecraft.NewManager(af, config.interval, mgr, mcMgrLog)
 
@@ -146,4 +125,41 @@ func subMain() error {
 	}
 
 	return nil
+}
+
+func setupWebhookCertWatcher(
+	config Config,
+	setupLog logr.Logger,
+) (*certwatcher.CertWatcher, []func(*tls.Config), error) {
+	// Create watchers for metrics and webhooks certificates
+	var webhookCertWatcher *certwatcher.CertWatcher
+	var tlsOpts []func(*tls.Config)
+	// Initial webhook TLS options
+	webhookTLSOpts := tlsOpts
+
+	if len(config.webhookCertPath) > 0 {
+		setupLog.Info(
+			"Initializing webhook certificate watcher using provided certificates",
+			"webhook-cert-path",
+			config.webhookCertPath,
+			"webhook-cert-name",
+			config.webhookCertName,
+			"webhook-cert-key",
+			config.webhookCertKey,
+		)
+
+		var err error
+		webhookCertWatcher, err = certwatcher.New(
+			filepath.Join(config.webhookCertPath, config.webhookCertName),
+			filepath.Join(config.webhookCertPath, config.webhookCertKey),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
+			config.GetCertificate = webhookCertWatcher.GetCertificate
+		})
+	}
+	return webhookCertWatcher, webhookTLSOpts, nil
 }

--- a/cmd/mcing-init/cmd/root.go
+++ b/cmd/mcing-init/cmd/root.go
@@ -7,19 +7,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "mcing-init",
-	Short: "mcing init",
-	Long:  "mcing init",
+// NewRootCmd represents the base command when called without any subcommands.
+func NewRootCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "mcing-init",
+		Short: "mcing init",
+		Long:  "mcing init",
 
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-		return subMain()
-	},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			return subMain()
+		},
+	}
 }
 
+// Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := NewRootCmd().Execute(); err != nil {
+		//nolint:forbidigo // cli output
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/mcing-init/cmd/run.go
+++ b/cmd/mcing-init/cmd/run.go
@@ -56,5 +56,5 @@ func copyFile(from, to string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(to, b, 0644)
+	return os.WriteFile(to, b, 0o600)
 }

--- a/config/crd/bases/mcing.kmdkuk.com_minecrafts.yaml
+++ b/config/crd/bases/mcing.kmdkuk.com_minecrafts.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Minecraft is the Schema for the minecrafts API
+        description: Minecraft is the Schema for the minecrafts API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: MinecraftSpec defines the desired state of Minecraft
+            description: MinecraftSpec defines the desired state of Minecraft.
             properties:
               ops:
                 description: operators on server. exec /op or /deop
@@ -9103,7 +9103,7 @@ spec:
             - volumeClaimTemplates
             type: object
           status:
-            description: MinecraftStatus defines the observed state of Minecraft
+            description: MinecraftStatus defines the observed state of Minecraft.
             type: object
         type: object
     served: true

--- a/docs/crd_minecraft.md
+++ b/docs/crd_minecraft.md
@@ -16,7 +16,7 @@
 
 #### Minecraft
 
-Minecraft is the Schema for the minecrafts API
+Minecraft is the Schema for the minecrafts API.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -28,7 +28,7 @@ Minecraft is the Schema for the minecrafts API
 
 #### MinecraftList
 
-MinecraftList contains a list of Minecraft
+MinecraftList contains a list of Minecraft.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -39,7 +39,7 @@ MinecraftList contains a list of Minecraft
 
 #### MinecraftSpec
 
-MinecraftSpec defines the desired state of Minecraft
+MinecraftSpec defines the desired state of Minecraft.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -68,7 +68,7 @@ ObjectMeta is metadata of objects. This is partially copied from metav1.ObjectMe
 
 #### Ops
 
-
+Ops represents the ops.json file.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -100,7 +100,7 @@ PodTemplateSpec describes the data a pod should have when created from a templat
 
 #### ServiceTemplate
 
-ServiceTemplate define the desired spec and annotations of Service
+ServiceTemplate define the desired spec and annotations of Service.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
@@ -111,7 +111,7 @@ ServiceTemplate define the desired spec and annotations of Service
 
 #### Whitelist
 
-
+Whitelist represents the whitelist.json file.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |

--- a/e2e/bootstrap_test.go
+++ b/e2e/bootstrap_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // dot imports for tests
+	. "github.com/onsi/gomega"    //nolint:revive // dot imports for tests
+
 	mcingv1alpha1 "github.com/kmdkuk/mcing/api/v1alpha1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 func testBootstrap() {

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -2,12 +2,13 @@ package e2e
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:revive // dot imports for tests
 	appsv1 "k8s.io/api/apps/v1"
 )
 
@@ -37,7 +38,7 @@ func kustomizeBuild(dir string) ([]byte, []byte, error) {
 
 func execAtLocal(cmd string, input []byte, args ...string) ([]byte, []byte, error) {
 	var stdout, stderr bytes.Buffer
-	command := exec.Command(cmd, args...)
+	command := exec.CommandContext(context.Background(), cmd, args...)
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 
@@ -56,7 +57,7 @@ func createNamespace(ns string) {
 	EventuallyWithOffset(1, func() error {
 		stdout, stderr, err := kubectl("get", "sa", "default", "-n", ns)
 		if err != nil {
-			return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			return fmt.Errorf("stdout: %s, stderr: %s, err: %w", stdout, stderr, err)
 		}
 		return nil
 	}).Should(Succeed())
@@ -66,7 +67,7 @@ func waitDeployment(namespace, name string, replicas int) {
 	EventuallyWithOffset(1, func() error {
 		stdout, stderr, err := kubectl("get", "deployment", name, "-n", namespace, "-o", "json")
 		if err != nil {
-			return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			return fmt.Errorf("stdout: %s, stderr: %s, err: %w", stdout, stderr, err)
 		}
 
 		d := new(appsv1.Deployment)
@@ -83,11 +84,11 @@ func waitDeployment(namespace, name string, replicas int) {
 	}).ShouldNot(HaveOccurred())
 }
 
-func waitStatefullSet(namespace, name string, replicas int) {
+func waitStatefullSet(namespace, name string, replicas int) { //nolint:unparam // replicas is always 1 in current tests
 	EventuallyWithOffset(1, func() error {
 		stdout, stderr, err := kubectl("get", "statefulset", name, "-n", namespace, "-o", "json")
 		if err != nil {
-			return fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			return fmt.Errorf("stdout: %s, stderr: %s, err: %w", stdout, stderr, err)
 		}
 
 		d := new(appsv1.StatefulSet)

--- a/e2e/manager_patch.yaml
+++ b/e2e/manager_patch.yaml
@@ -5,7 +5,5 @@
   path: /spec/template/spec/containers/0/args/-
   value: --agent-image-name=mcing-agent:e2e
 - op: add
-  path: /spec/template/spec/containers/0/env/-
-  value: 
-    name: DEBUG_CONTROLLER
-    value: "1"
+  path: /spec/template/spec/containers/0/args/-
+  value: --init-image-name=mcing-init:e2e

--- a/e2e/ops_whitelist_test.go
+++ b/e2e/ops_whitelist_test.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // dot imports for tests
+	. "github.com/onsi/gomega"    //nolint:revive // dot imports for tests
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/kmdkuk/mcing/pkg/config"
 	"github.com/kmdkuk/mcing/pkg/constants"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 )
 
 //go:embed testdata/add-ops-whitelist.yaml
@@ -19,48 +20,73 @@ var addOpsWhitelistYAML string
 //go:embed testdata/no-ops-whitelist.yaml
 var noOpsWhitelistYAML string
 
+//nolint:funlen // long test case
 func testOpsWhitelist() {
 	stsName := "mcing-ops-whitelist"
-	type userJson struct {
+	type userJSON struct {
 		Name string `json:"name"`
 	}
 	It("should create no ops and whitelist", func() {
 		kubectlSafeWithInput([]byte(noOpsWhitelistYAML), "apply", "-f", "-")
 		waitStatefullSet("default", stsName, 1)
 		Eventually(func(g Gomega) {
-			stdout, _, err := kubectl("exec", stsName+"-0", "--", "cat", filepath.Join(constants.DataPath, constants.OpsName))
+			stdout, _, err := kubectl(
+				"exec",
+				stsName+"-0",
+				"--",
+				"cat",
+				filepath.Join(constants.DataPath, constants.OpsName),
+			)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			var ops []userJson
+			var ops []userJSON
 			err = json.Unmarshal(stdout, &ops)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(ops).Should(HaveLen(0))
+			g.Expect(ops).Should(BeEmpty())
 
-			stdout, _, err = kubectl("exec", stsName+"-0", "--", "cat", filepath.Join(constants.DataPath, constants.ServerPropsName))
+			stdout, _, err = kubectl(
+				"exec",
+				stsName+"-0",
+				"--",
+				"cat",
+				filepath.Join(constants.DataPath, constants.ServerPropsName),
+			)
 			g.Expect(err).ShouldNot(HaveOccurred())
 
 			bf := bytes.NewBuffer(stdout)
 			props, err := config.ParseServerProps(bf)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(props[constants.WhitelistProps]).Should(Equal("false"))
-		})
+		}).Should(Succeed())
 	})
 
 	It("should apply 1 ops and whitelist", func() {
 		kubectlSafeWithInput([]byte(addOpsWhitelistYAML), "apply", "-f", "-")
 		waitStatefullSet("default", stsName, 1)
 		Eventually(func(g Gomega) {
-			stdout, _, err := kubectl("exec", stsName+"-0", "--", "cat", filepath.Join(constants.DataPath, constants.OpsName))
+			stdout, _, err := kubectl(
+				"exec",
+				stsName+"-0",
+				"--",
+				"cat",
+				filepath.Join(constants.DataPath, constants.OpsName),
+			)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			type opsJson struct {
+			type opsJSON struct {
 				Name string `json:"name"`
 			}
-			var ops []opsJson
+			var ops []opsJSON
 			err = json.Unmarshal(stdout, &ops)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(ops).Should(HaveLen(1))
 			g.Expect(ops[0].Name).Should(Equal("kmdkuk"))
 
-			stdout, _, err = kubectl("exec", stsName+"-0", "--", "cat", filepath.Join(constants.DataPath, constants.ServerPropsName))
+			stdout, _, err = kubectl(
+				"exec",
+				stsName+"-0",
+				"--",
+				"cat",
+				filepath.Join(constants.DataPath, constants.ServerPropsName),
+			)
 			g.Expect(err).ShouldNot(HaveOccurred())
 
 			bf := bytes.NewBuffer(stdout)
@@ -68,38 +94,56 @@ func testOpsWhitelist() {
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(props[constants.WhitelistProps]).Should(Equal("true"))
 
-			stdout, _, err = kubectl("exec", stsName+"-0", "--", "cat", filepath.Join(constants.DataPath, constants.WhiteListName))
+			stdout, _, err = kubectl(
+				"exec",
+				stsName+"-0",
+				"--",
+				"cat",
+				filepath.Join(constants.DataPath, constants.WhiteListName),
+			)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			var whitelist []userJson
+			var whitelist []userJSON
 			err = json.Unmarshal(stdout, &whitelist)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(whitelist).Should(HaveLen(1))
 			g.Expect(whitelist[0].Name).Should(Equal("kmdkuk"))
-		})
+		}).Should(Succeed())
 	})
 
 	It("should apply no ops and whitelist", func() {
 		kubectlSafeWithInput([]byte(noOpsWhitelistYAML), "apply", "-f", "-")
 		waitStatefullSet("default", stsName, 1)
 		Eventually(func(g Gomega) {
-			stdout, _, err := kubectl("exec", stsName+"-0", "--", "cat", filepath.Join(constants.DataPath, constants.OpsName))
+			stdout, _, err := kubectl(
+				"exec",
+				stsName+"-0",
+				"--",
+				"cat",
+				filepath.Join(constants.DataPath, constants.OpsName),
+			)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			type opsJson struct {
+			type opsJSON struct {
 				Name string `json:"name"`
 			}
-			var ops []opsJson
+			var ops []opsJSON
 			err = json.Unmarshal(stdout, &ops)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(ops).Should(HaveLen(0))
+			g.Expect(ops).Should(BeEmpty())
 
-			stdout, _, err = kubectl("exec", stsName+"-0", "--", "cat", filepath.Join(constants.DataPath, constants.ServerPropsName))
+			stdout, _, err = kubectl(
+				"exec",
+				stsName+"-0",
+				"--",
+				"cat",
+				filepath.Join(constants.DataPath, constants.ServerPropsName),
+			)
 			g.Expect(err).ShouldNot(HaveOccurred())
 
 			bf := bytes.NewBuffer(stdout)
 			props, err := config.ParseServerProps(bf)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(props[constants.WhitelistProps]).Should(Equal("false"))
-		})
+		}).Should(Succeed())
 	})
 
 	It("should delete ops-whitelist instance", func() {
@@ -110,7 +154,7 @@ func testOpsWhitelist() {
 			pods := &corev1.PodList{}
 			err = json.Unmarshal(stdout, pods)
 			g.Expect(err).ShouldNot(HaveOccurred())
-			g.Expect(pods).Should(HaveLen(0))
-		})
+			g.Expect(pods.Items).Should(BeEmpty())
+		}).Should(Succeed())
 	})
 }

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -5,17 +5,16 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // dot imports for tests
+	. "github.com/onsi/gomega"    //nolint:revive // dot imports for tests
 )
 
 const (
 	controllerNS = "mcing-system"
 )
 
-var (
-	binDir = os.Getenv("BIN_DIR")
-)
+//nolint:gochecknoglobals // test setup
+var binDir = os.Getenv("BIN_DIR")
 
 func TestE2e(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/controller/mock_test.go
+++ b/internal/controller/mock_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/kmdkuk/mcing/internal/minecraft"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kmdkuk/mcing/internal/minecraft"
 )
 
 type mockManager struct {
@@ -13,7 +14,7 @@ type mockManager struct {
 	minecrafts map[string]struct{}
 }
 
-var _ minecraft.MinecraftManager = &mockManager{}
+var _ minecraft.MinecraftManager = &mockManager{} //nolint:exhaustruct // interface check
 
 func (m *mockManager) Update(key types.NamespacedName) error {
 	m.mu.Lock()

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -7,10 +7,8 @@ import (
 	"testing"
 	"time"
 
-	mcingv1alpha1 "github.com/kmdkuk/mcing/api/v1alpha1"
-	"github.com/kmdkuk/mcing/pkg/constants"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // dot imports for tests
+	. "github.com/onsi/gomega"    //nolint:revive // dot imports for tests
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -22,16 +20,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	mcingv1alpha1 "github.com/kmdkuk/mcing/api/v1alpha1"
+	"github.com/kmdkuk/mcing/pkg/constants"
 	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var k8sCfg *rest.Config
-var k8sClient client.Client
-var scheme *runtime.Scheme
-var testEnv *envtest.Environment
+//nolint:gochecknoglobals // test setup
+var (
+	k8sCfg    *rest.Config
+	k8sClient client.Client
+	scheme    *runtime.Scheme
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -75,7 +79,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
 })
 
 var _ = AfterSuite(func() {
@@ -126,7 +129,9 @@ func makeMinecraft(name, namespace string) *mcingv1alpha1.Minecraft {
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 						Resources: corev1.VolumeResourceRequirements{
-							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+							Requests: corev1.ResourceList{ //nolint:exhaustive // resource list
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
 						},
 					},
 				},

--- a/internal/minecraft/mock_test.go
+++ b/internal/minecraft/mock_test.go
@@ -3,9 +3,10 @@ package minecraft
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/kmdkuk/mcing/pkg/agent"
 	"github.com/kmdkuk/mcing/pkg/proto"
-	"google.golang.org/grpc"
 )
 
 type mockAgentConn struct {
@@ -14,21 +15,33 @@ type mockAgentConn struct {
 	syncOpsFunc       func(ctx context.Context, in *proto.SyncOpsRequest, opts ...grpc.CallOption) (*proto.SyncOpsResponse, error)
 }
 
-func (m *mockAgentConn) Reload(ctx context.Context, in *proto.ReloadRequest, opts ...grpc.CallOption) (*proto.ReloadResponse, error) {
+func (m *mockAgentConn) Reload(
+	ctx context.Context,
+	in *proto.ReloadRequest,
+	opts ...grpc.CallOption,
+) (*proto.ReloadResponse, error) {
 	if m.reloadFunc != nil {
 		return m.reloadFunc(ctx, in, opts...)
 	}
 	return &proto.ReloadResponse{}, nil
 }
 
-func (m *mockAgentConn) SyncWhitelist(ctx context.Context, in *proto.SyncWhitelistRequest, opts ...grpc.CallOption) (*proto.SyncWhitelistResponse, error) {
+func (m *mockAgentConn) SyncWhitelist(
+	ctx context.Context,
+	in *proto.SyncWhitelistRequest,
+	opts ...grpc.CallOption,
+) (*proto.SyncWhitelistResponse, error) {
 	if m.syncWhitelistFunc != nil {
 		return m.syncWhitelistFunc(ctx, in, opts...)
 	}
 	return &proto.SyncWhitelistResponse{}, nil
 }
 
-func (m *mockAgentConn) SyncOps(ctx context.Context, in *proto.SyncOpsRequest, opts ...grpc.CallOption) (*proto.SyncOpsResponse, error) {
+func (m *mockAgentConn) SyncOps(
+	ctx context.Context,
+	in *proto.SyncOpsRequest,
+	opts ...grpc.CallOption,
+) (*proto.SyncOpsResponse, error) {
 	if m.syncOpsFunc != nil {
 		return m.syncOpsFunc(ctx, in, opts...)
 	}
@@ -39,4 +52,4 @@ func (m *mockAgentConn) Close() error {
 	return nil
 }
 
-var _ agent.AgentConn = &mockAgentConn{}
+var _ agent.Conn = &mockAgentConn{} //nolint:exhaustruct // interface check

--- a/pkg/config/server_props.go
+++ b/pkg/config/server_props.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"sort"
 	"strconv"
@@ -12,69 +13,78 @@ import (
 	"github.com/kmdkuk/mcing/pkg/constants"
 )
 
-var defaultServerProps = map[string]string{
-	"enable-jmx-monitoring":             "false",
-	"level-seed":                        "",
-	"enable-command-block":              "true",
-	"gamemode":                          "survival",
-	"enable-query":                      "false",
-	"generator-settings":                "",
-	"level-name":                        "world",
-	"motd":                              "A Vanilla Minecraft Server powered by MCing",
-	"texture-pack":                      "",
-	"pvp":                               "true",
-	"generate-structures":               "true",
-	"difficulty":                        "easy",
-	"network-compression-threshold":     "256",
-	"max-tick-time":                     "60000",
-	"require-resource-pack":             "false",
-	"max-players":                       "20",
-	"use-native-transport":              "true",
-	"online-mode":                       "true",
-	"enable-status":                     "true",
-	"allow-flight":                      "false",
-	"broadcast-rcon-to-ops":             "true",
-	"view-distance":                     "10",
-	"max-build-height":                  "256",
-	"server-ip":                         "",
-	"resource-pack-prompt":              "",
-	"allow-nether":                      "true",
-	"enable-rcon":                       "true",
-	"sync-chunk-writes":                 "true",
-	"op-permission-level":               "4",
-	"server-name":                       "Dedicated Server",
-	"prevent-proxy-connections":         "false",
-	"resource-pack":                     "",
-	"entity-broadcast-range-percentage": "100",
-	"player-idle-timeout":               "0",
-	"rcon.password":                     "minecraft",
-	"force-gamemode":                    "false",
-	"rate-limit":                        "0",
-	"hardcore":                          "false",
-	"white-list":                        "false",
-	"broadcast-console-to-ops":          "true",
-	"spawn-npcs":                        "true",
-	"spawn-animals":                     "true",
-	"snooper-enabled":                   "true",
-	"function-permission-level":         "2",
-	"level-type":                        "DEFAULT",
-	"text-filtering-config":             "",
-	"spawn-monsters":                    "true",
-	"enforce-whitelist":                 "false",
-	"resource-pack-sha1":                "",
-	"spawn-protection":                  "16",
-	"max-world-size":                    "29999984",
+const maxSplitParts = 2
+
+// DefaultServerProps returns the default server properties.
+func DefaultServerProps() map[string]string {
+	return map[string]string{
+		"enable-jmx-monitoring":             "false",
+		"level-seed":                        "",
+		"enable-command-block":              "true",
+		"gamemode":                          "survival",
+		"enable-query":                      "false",
+		"generator-settings":                "",
+		"level-name":                        "world",
+		"motd":                              "A Vanilla Minecraft Server powered by MCing",
+		"texture-pack":                      "",
+		"pvp":                               "true",
+		"generate-structures":               "true",
+		"difficulty":                        "easy",
+		"network-compression-threshold":     "256",
+		"max-tick-time":                     "60000",
+		"require-resource-pack":             "false",
+		"max-players":                       "20",
+		"use-native-transport":              "true",
+		"online-mode":                       "true",
+		"enable-status":                     "true",
+		"allow-flight":                      "false",
+		"broadcast-rcon-to-ops":             "true",
+		"view-distance":                     "10",
+		"max-build-height":                  "256",
+		"server-ip":                         "",
+		"resource-pack-prompt":              "",
+		"allow-nether":                      "true",
+		"enable-rcon":                       "true",
+		"sync-chunk-writes":                 "true",
+		"op-permission-level":               "4",
+		"server-name":                       "Dedicated Server",
+		"prevent-proxy-connections":         "false",
+		"resource-pack":                     "",
+		"entity-broadcast-range-percentage": "100",
+		"player-idle-timeout":               "0",
+		"rcon.password":                     "minecraft",
+		"force-gamemode":                    "false",
+		"rate-limit":                        "0",
+		"hardcore":                          "false",
+		"white-list":                        "false",
+		"broadcast-console-to-ops":          "true",
+		"spawn-npcs":                        "true",
+		"spawn-animals":                     "true",
+		"snooper-enabled":                   "true",
+		"function-permission-level":         "2",
+		"level-type":                        "DEFAULT",
+		"text-filtering-config":             "",
+		"spawn-monsters":                    "true",
+		"enforce-whitelist":                 "false",
+		"resource-pack-sha1":                "",
+		"spawn-protection":                  "16",
+		"max-world-size":                    "29999984",
+	}
 }
 
-var constServerProps = map[string]string{
-	"rcon.port":   strconv.Itoa(int(constants.RconPort)),
-	"query.port":  strconv.Itoa(int(constants.ServerPort)),
-	"server-port": strconv.Itoa(int(constants.ServerPort)),
+// ConstServerProps returns the constant server properties.
+func ConstServerProps() map[string]string {
+	return map[string]string{
+		"rcon.port":   strconv.Itoa(int(constants.RconPort)),
+		"query.port":  strconv.Itoa(int(constants.ServerPort)),
+		"server-port": strconv.Itoa(int(constants.ServerPort)),
+	}
 }
 
+// GenServerProps generates server.properties content.
 func GenServerProps(userProps map[string]string) (string, error) {
-	serverProps := mergeProps(defaultServerProps, userProps)
-	serverProps = mergeProps(serverProps, constServerProps)
+	serverProps := mergeProps(DefaultServerProps(), userProps)
+	serverProps = mergeProps(serverProps, ConstServerProps())
 
 	keys := make([]string, 0, len(serverProps))
 	for k := range serverProps {
@@ -95,17 +105,14 @@ func GenServerProps(userProps map[string]string) (string, error) {
 func mergeProps(props1, props2 map[string]string) map[string]string {
 	props := make(map[string]string)
 
-	for k, v := range props1 {
-		props[k] = v
-	}
+	maps.Copy(props, props1)
 
-	for k, v := range props2 {
-		props[k] = v
-	}
+	maps.Copy(props, props2)
 
 	return props
 }
 
+// ParseServerPropsFromPath parses server.properties from path.
 func ParseServerPropsFromPath(path string) (_ map[string]string, err error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -118,6 +125,7 @@ func ParseServerPropsFromPath(path string) (_ map[string]string, err error) {
 	return ParseServerProps(f)
 }
 
+// ParseServerProps parses server.properties from reader.
 func ParseServerProps(r io.Reader) (map[string]string, error) {
 	props := make(map[string]string)
 	scanner := bufio.NewScanner(r)
@@ -129,8 +137,8 @@ func ParseServerProps(r io.Reader) (map[string]string, error) {
 		if l == "" {
 			continue
 		}
-		split := strings.SplitN(l, "=", 2)
-		if len(split) != 2 {
+		split := strings.SplitN(l, "=", maxSplitParts)
+		if len(split) != maxSplitParts {
 			continue
 		}
 		props[split[0]] = split[1]

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,6 +1,6 @@
 package constants
 
-// Metadata
+// Metadata.
 const (
 	MetaPrefix = "mcing.kmdkuk.com/"
 	Finalizer  = MetaPrefix + "finalizer"
@@ -15,7 +15,7 @@ const (
 	ControllerName     = "mcing-controller"
 )
 
-// Container
+// Container.
 const (
 	MinecraftContainerName = "minecraft"
 	ServerPortName         = "server-port"
@@ -50,12 +50,15 @@ const (
 )
 
 const (
-	EulaEnvName           = "EULA"
-	RconPasswordEnvName   = "RCON_PASSWORD"
+	// EulaEnvName is the environment variable name for EULA.
+	EulaEnvName = "EULA"
+	// RconPasswordEnvName is the environment variable name for RCON password.
+	RconPasswordEnvName = "RCON_PASSWORD"
+	// RconPasswordSecretKey is the secret key for RCON password.
 	RconPasswordSecretKey = "rcon-password"
 )
 
-// server.properties
+// server.properties.
 const (
 	WhitelistProps = "white-list"
 	RconPortProps  = "rcon.port"

--- a/pkg/rcon/rcon.go
+++ b/pkg/rcon/rcon.go
@@ -7,6 +7,7 @@ import (
 	"github.com/james4k/rcon"
 )
 
+// NewConn creates a new RCON connection.
 func NewConn(hostPort, password string) (*rcon.RemoteConsole, error) {
 	remoteConsole, err := rcon.Dial(hostPort, password)
 	if err != nil {
@@ -19,33 +20,33 @@ func NewConn(hostPort, password string) (*rcon.RemoteConsole, error) {
 
 func exec(remoteConsole *rcon.RemoteConsole, command ...string) (string, error) {
 	preparedCmd := strings.Join(command, " ")
-	reqId, err := remoteConsole.Write(preparedCmd)
+	reqID, err := remoteConsole.Write(preparedCmd)
 	if err != nil {
 		return "", err
 	}
 
-	resp, respReqId, err := remoteConsole.Read()
+	resp, respReqID, err := remoteConsole.Read()
 	if err != nil {
 		return "", fmt.Errorf("failed to read command: %w", err)
-
 	}
 
-	if reqId != respReqId {
+	if reqID != respReqID {
 		return "", fmt.Errorf("weird. this response is for another request. message: %s", resp)
 	}
 
 	return resp, nil
 }
 
+// Reload reloads the server.
 func Reload(remoteConsole *rcon.RemoteConsole) error {
-	str, err := exec(remoteConsole, "reload")
+	_, err := exec(remoteConsole, "reload")
 	if err != nil {
 		return err
 	}
-	fmt.Println(str)
 	return nil
 }
 
+// WhitelistSwitch switches the whitelist on/off.
 func WhitelistSwitch(remoteConsole *rcon.RemoteConsole, enabled bool) error {
 	arg := "on"
 	if !enabled {
@@ -55,6 +56,7 @@ func WhitelistSwitch(remoteConsole *rcon.RemoteConsole, enabled bool) error {
 	return err
 }
 
+// Whitelist adds or removes users from the whitelist.
 func Whitelist(remoteConsole *rcon.RemoteConsole, action string, users []string) error {
 	if action != "add" && action != "remove" {
 		return fmt.Errorf("action must be add or remove. action: %s", action)
@@ -68,6 +70,7 @@ func Whitelist(remoteConsole *rcon.RemoteConsole, action string, users []string)
 	return nil
 }
 
+// ListWhitelist lists whitelisted users.
 func ListWhitelist(remoteConsole *rcon.RemoteConsole) ([]string, error) {
 	// There are 2 whitelisted players: hoge, fuga
 	liststr, err := exec(remoteConsole, "whitelist", "list")
@@ -89,6 +92,7 @@ func ListWhitelist(remoteConsole *rcon.RemoteConsole) ([]string, error) {
 	return users, nil
 }
 
+// Op adds users to the op list.
 func Op(remoteConsole *rcon.RemoteConsole, users []string) error {
 	var errUsers []string
 	for _, user := range users {
@@ -106,6 +110,7 @@ func Op(remoteConsole *rcon.RemoteConsole, users []string) error {
 	return nil
 }
 
+// Deop removes users from the op list.
 func Deop(remoteConsole *rcon.RemoteConsole, users []string) error {
 	for _, user := range users {
 		_, err := exec(remoteConsole, "deop", user)

--- a/pkg/server/reload.go
+++ b/pkg/server/reload.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kmdkuk/mcing/pkg/rcon"
 )
 
-func (s agentService) Reload(ctx context.Context, req *proto.ReloadRequest) (*proto.ReloadResponse, error) {
+func (s agentService) Reload(_ context.Context, _ *proto.ReloadRequest) (*proto.ReloadResponse, error) {
 	if err := rcon.Reload(s.conn); err != nil {
 		return nil, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,20 +2,22 @@ package server
 
 import (
 	"github.com/james4k/rcon"
-	"github.com/kmdkuk/mcing/pkg/proto"
 	"go.uber.org/zap"
+
+	"github.com/kmdkuk/mcing/pkg/proto"
 )
 
-// NewAgentService creates a new AgentServer
+// NewAgentService creates a new AgentServer.
 func NewAgentService(logger *zap.Logger, conn *rcon.RemoteConsole) proto.AgentServer {
-	return agentService{
+	return agentService{ //nolint:exhaustruct // unimplemented embedded struct
 		logger: logger.With(zap.String("service", "mcing-agent")),
 		conn:   conn,
 	}
 }
 
 type agentService struct {
+	proto.UnimplementedAgentServer
+
 	logger *zap.Logger
 	conn   *rcon.RemoteConsole
-	proto.UnimplementedAgentServer
 }

--- a/pkg/server/sync.go
+++ b/pkg/server/sync.go
@@ -7,14 +7,18 @@ import (
 	"path"
 	"strconv"
 
+	"go.uber.org/zap"
+
 	"github.com/kmdkuk/mcing/pkg/config"
 	"github.com/kmdkuk/mcing/pkg/constants"
 	"github.com/kmdkuk/mcing/pkg/proto"
 	"github.com/kmdkuk/mcing/pkg/rcon"
-	"go.uber.org/zap"
 )
 
-func (s agentService) SyncWhitelist(ctx context.Context, req *proto.SyncWhitelistRequest) (*proto.SyncWhitelistResponse, error) {
+func (s agentService) SyncWhitelist(
+	_ context.Context,
+	req *proto.SyncWhitelistRequest,
+) (*proto.SyncWhitelistResponse, error) {
 	log := s.logger.With(zap.String("func", "syncWhitelist"))
 	log.Info("start sync white list")
 	// parse /data/server.peroperties using config.ParseServerProps
@@ -26,12 +30,13 @@ func (s agentService) SyncWhitelist(ctx context.Context, req *proto.SyncWhitelis
 	if err != nil {
 		return &proto.SyncWhitelistResponse{}, err
 	}
-	if enabled != req.Enabled {
-		if err := rcon.WhitelistSwitch(s.conn, req.Enabled); err != nil {
+	if enabled != req.GetEnabled() {
+		err = rcon.WhitelistSwitch(s.conn, req.GetEnabled())
+		if err != nil {
 			return &proto.SyncWhitelistResponse{}, err
 		}
 	}
-	if !req.Enabled {
+	if !req.GetEnabled() {
 		return &proto.SyncWhitelistResponse{}, nil
 	}
 	users, err := rcon.ListWhitelist(s.conn)
@@ -40,14 +45,14 @@ func (s agentService) SyncWhitelist(ctx context.Context, req *proto.SyncWhitelis
 	}
 	log.Info("current whitelist", zap.Strings("users", users))
 	// add: Not present in users, but present in req.Users.
-	addUsers := differenceSet(users, req.Users)
+	addUsers := differenceSet(users, req.GetUsers())
 	if len(addUsers) > 0 {
 		if err := rcon.Whitelist(s.conn, "add", addUsers); err != nil {
 			return &proto.SyncWhitelistResponse{}, err
 		}
 	}
 	// remove: Not present in req.Users, but present in users.
-	removeUsers := differenceSet(req.Users, users)
+	removeUsers := differenceSet(req.GetUsers(), users)
 	if len(removeUsers) > 0 {
 		err := rcon.Whitelist(s.conn, "remove", removeUsers)
 		if err != nil {
@@ -58,21 +63,21 @@ func (s agentService) SyncWhitelist(ctx context.Context, req *proto.SyncWhitelis
 	return &proto.SyncWhitelistResponse{}, nil
 }
 
-type opsJson struct {
-	Uuid                string `json:"uuid"`
+type opsJSON struct {
+	UUID                string `json:"uuid"`
 	Name                string `json:"name"`
 	Level               int    `json:"level"`
 	BypassesPlayerLimit bool   `json:"bypassesPlayerLimit"`
 }
 
-func (s agentService) SyncOps(ctx context.Context, req *proto.SyncOpsRequest) (*proto.SyncOpsResponse, error) {
+func (s agentService) SyncOps(_ context.Context, req *proto.SyncOpsRequest) (*proto.SyncOpsResponse, error) {
 	log := s.logger.With(zap.String("func", "syncOps"))
 	log.Info("start sync ops")
 	raw, err := os.ReadFile(path.Join(constants.DataPath, constants.OpsName))
 	if err != nil {
 		return &proto.SyncOpsResponse{}, err
 	}
-	var ops []opsJson
+	var ops []opsJSON
 	if err := json.Unmarshal(raw, &ops); err != nil {
 		return &proto.SyncOpsResponse{}, err
 	}
@@ -81,7 +86,7 @@ func (s agentService) SyncOps(ctx context.Context, req *proto.SyncOpsRequest) (*
 		users = append(users, v.Name)
 	}
 
-	addUsers := differenceSet(users, req.Users)
+	addUsers := differenceSet(users, req.GetUsers())
 	if len(addUsers) > 0 {
 		err := rcon.Op(s.conn, addUsers)
 		if err != nil {
@@ -89,7 +94,7 @@ func (s agentService) SyncOps(ctx context.Context, req *proto.SyncOpsRequest) (*
 		}
 	}
 	// remove: Not present in req.Users, but present in users.
-	removeUsers := differenceSet(req.Users, users)
+	removeUsers := differenceSet(req.GetUsers(), users)
 	if len(removeUsers) > 0 {
 		err := rcon.Deop(s.conn, removeUsers)
 		if err != nil {

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -1,13 +1,12 @@
-package utils
+package utils //nolint:revive // utils is a common package name
 
+import "maps"
+
+// MergeMap merges two maps.
 func MergeMap(m1, m2 map[string]string) map[string]string {
 	m := make(map[string]string)
-	for k, v := range m1 {
-		m[k] = v
-	}
-	for k, v := range m2 {
-		m[k] = v
-	}
+	maps.Copy(m, m1)
+	maps.Copy(m, m2)
 	if len(m) == 0 {
 		return nil
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,11 @@
 package version
 
+//nolint:gochecknoglobals // set by ldflags
 var (
-	Version   = "e2e"
-	Revision  = "unset"
+	// Version is the version of mcing.
+	Version = "e2e"
+	// Revision is the git revision of mcing.
+	Revision = "unset"
+	// BuildDate is the build date of mcing.
 	BuildDate = ""
 )

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,3 +1,4 @@
+//nolint:cyclop // complex logic
 package watcher
 
 import (
@@ -8,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	james4krcon "github.com/james4k/rcon"
+
 	"github.com/kmdkuk/mcing/pkg/log"
 	"github.com/kmdkuk/mcing/pkg/rcon"
 )
@@ -19,6 +21,9 @@ const (
 	serverPropsPath = configPath + "/" + serverPropsName
 )
 
+// Watch watches the RCON server.
+//
+//nolint:cyclop,gocognit // complex logic
 func Watch(ctx context.Context, conn *james4krcon.RemoteConsole, interval time.Duration) error {
 	tick := time.NewTicker(interval)
 	defer tick.Stop()
@@ -53,7 +58,7 @@ func Watch(ctx context.Context, conn *james4krcon.RemoteConsole, interval time.D
 			if err != nil {
 				continue
 			}
-			err = os.WriteFile(dataPath, current, 0644)
+			err = os.WriteFile(dataPath, current, 0o600)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
## Summary
Enforce strict `golangci-lint` rules and resolve identified linting errors.

## Changes
- Update `.golangci.yml` configuration to enable stricter linters.
- Fix lint errors across `pkg`, `cmd`, `internal`, and `api` directories.
  - Handle global variables appropriately (`gochecknoglobals`) or apply `nolint`.
  - Address complexity issues (`cyclop`, `gocognit`) with refactoring or `nolint`.
  - Fix file permissions in `pkg/watcher` (`gosec`).
  - Correct formatting and naming conventions.
- Refactor `pkg/utils/map.go` to use `maps.Copy`.

## Tests
- Confirmed `make lint` passes.
- Confirmed `make test` passes.
